### PR TITLE
Manual "shadow" divs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# box-colors
+# Falling Color Boxes #
+
+Inspired by [Jennifer Dewalt's](https://github.com/jendewalt) lovely [Technicolor Boxes](https://jenniferdewalt.com/technicolor_boxes.html). Written for [Academy Pittsburgh](https://www.academypgh.com) Session 14, on May 19th, 2022.
+
+An opportunity for me to learn about:
+
+* [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)
+* Dynamically setting CSS styles
+* Changing element sizes and counts for responsive design

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
 
 <body>
   <div id="tile-container">
-    <div class="tile" onmouseenter="overTile(this)" ontouchstart="overTile(this)"></div>
   </div>
 </body>
 

--- a/main.js
+++ b/main.js
@@ -31,7 +31,6 @@ function overTile(tile) {
   const offsetX = Math.floor(400 * Math.random()) - 200
 
   const droppingKeyframes = [
-    { transform: '' },
     {
       transform: `translate(${offsetX}px, 150vh) rotate(${finalAngle}deg)`,
       boxShadow: `20px 20px 20px black`

--- a/main.js
+++ b/main.js
@@ -5,14 +5,12 @@ const observer = new IntersectionObserver(entries => {
   entries.forEach(entry => {
     if (entry.isIntersecting) {
       entry.target.loaded = true
-
     }
     else if (entry.target.loaded) {
       entry.target.remove()
     }
   })
 })
-
 
 function overTile(tile) {
   const rect = tile.getBoundingClientRect()
@@ -42,8 +40,7 @@ function overTile(tile) {
 
   const droppingOptions = {
     duration: 1000,
-    easing: 'ease-in',
-    // iterations: 1,
+    easing: 'ease-in'
   }
 
   document.body.appendChild(overTile)
@@ -67,15 +64,6 @@ window.addEventListener("resize", () => {
   setTiles()
   // debounce(setTileDim, 500)
 })
-
-
-// function setTileDim() {
-//   const targetDim = 100
-//   const windowWidth = window.innerWidth
-//   const tilesPerRow = Math.max(1, Math.round(windowWidth / targetDim))
-//   const tileDim = Math.floor(windowWidth / tilesPerRow)
-//   document.documentElement.style.setProperty('--tile-dim', `${tileDim}px`);
-// }
 
 function setTiles() {
   const targetDim = 100

--- a/style.css
+++ b/style.css
@@ -1,9 +1,3 @@
-:root {
-  /* --tile-dim: calc(10vw - 10px); */
-  /* --tile-dim: calc(100vw / calc(round(100vw / 100px))); */
-  --tile-dim: 100px;
-}
-
 body {
   position: relative;
   margin: 0;
@@ -11,6 +5,7 @@ body {
   box-sizing: border-box;
   background-color: gray;
   touch-action: none;
+  overflow: hidden;
 }
 
 #tile-container {
@@ -21,15 +16,11 @@ body {
   justify-content: center;
   align-content: flex-start;
   height: 100vh;
-  overflow: hidden;
   touch-action: none;
 }
 
 .tile {
-  /* position: relative; */
-  /* width: 100px; */
   width: var(--tile-dim);
-  /* height: 100px; */
   height: var(--tile-dim);
   flex-basis: auto;
   background-color: gray;
@@ -41,15 +32,4 @@ body {
 .tile.over {
   position: absolute;
   box-shadow: 0 0 0 black;
-  /* top: 0;
-  left: 0; */
-  /* background-color: red; */
-  /* z-index: 100; */
-  /* animation: drop 1s ease-in; */
 }
-
-/* @keyframes drop {
-  100% {
-    transform: translateY(150vh) rotate(360deg);
-  }
-} */


### PR DESCRIPTION
Experimenting with having independent `divs` shadow the falling boxes instead of using `box-shadow`, to keep the light source consistent as the box rotates.